### PR TITLE
Added option to selectively skip nodes

### DIFF
--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -102,6 +102,12 @@ class ExportDAE(bpy.types.Operator, ExportHelper):
         description="Export only objects on the active layers.",
         default=True,
         )
+    use_node_skip_noexp = BoolProperty(
+        name="Skip (-noexp) Nodes",
+        description="Skip exporting of nodes whose name end in (-noexp)."
+                    " Useful to skip lights, etc. which were only used for modelling.",
+        default=True,
+        )
     use_exclude_ctrl_bones = BoolProperty(
         name="Exclude Control Bones",
         description=("Exclude skeleton bones with names beginning with 'ctrl' "

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -1452,6 +1452,9 @@ class DaeExporter:
         if (node not in self.valid_nodes):
             return
 
+        if (self.config["use_node_skip_noexp"] and node.name.endswith("-noexp")):
+            return
+
         prev_node = bpy.context.scene.objects.active
         bpy.context.scene.objects.active = node
 


### PR DESCRIPTION
Added functionality to selectively skip nodes by adding -noexp to their name. This is useful for lights or cameras that were used only for previewing a model, or empties that were used for anchoring a modifier that has been applied.